### PR TITLE
feat: add environment configuration templates

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,12 @@
+# MongoDB Database Configuration
+MONGO_URI=mongodb://localhost:27017/paisable_db
+
+# JWT Secret Key (use a strong, random string in production)
+JWT_SECRET=your-super-secret-jwt-key-here
+
+# Google Generative AI (Gemini) API Key
+# Get your API key from: https://aistudio.google.com/apikey
+GEMINI_API_KEY=your-gemini-api-key-here
+
+# Server Port (optional, defaults to 5000)
+PORT=5000

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,4 @@
+# Backend API URL
+# For development, use your local backend server
+# For production, use your deployed backend URL
+VITE_API_URL=http://localhost:5000

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -23,4 +23,7 @@ dist-ssr
 *.sln
 *.sw?
 
-.env.*
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local


### PR DESCRIPTION
This pull request adds example environment variable files for both the backend and frontend, providing clear configuration templates for local development and production. It also updates the frontend `.gitignore` to more precisely ignore only sensitive local environment files, rather than all `.env.*` files.

**Environment configuration improvements:**

* Added `backend/.env.example` with sample variables for MongoDB, JWT secret, Gemini API key, and server port to guide backend setup.
* Added `frontend/.env.example` with a sample API URL to guide frontend setup.

**.gitignore update:**

* Updated `frontend/.gitignore` to ignore only specific local environment files (`.env.local`, `.env.development.local`, `.env.test.local`, `.env.production.local`), making it safer to commit example env files and reducing risk of leaking sensitive data.