### PR TITLE
Test/currency persistence

### DIFF
--- a/frontend/src/components/CurrencySelector.test.jsx
+++ b/frontend/src/components/CurrencySelector.test.jsx
@@ -1,0 +1,113 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import CurrencySelector from './CurrencySelector';
+import { CurrencyProvider } from '../contexts/CurrencyContext';
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store = {};
+  return {
+    getItem: vi.fn((key) => store[key] || null),
+    setItem: vi.fn((key, value) => {
+      store[key] = value.toString();
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+});
+
+describe('CurrencySelector - localStorage persistence', () => {
+  beforeEach(() => {
+    // Clear localStorage and reset mocks before each test
+    localStorageMock.clear();
+    vi.clearAllMocks();
+  });
+
+  it('should persist currency selection to localStorage and reload it on re-render', async () => {
+    const user = userEvent.setup();
+
+    // Initial render - should show USD (default currency)
+    const { unmount } = render(
+      <CurrencyProvider>
+        <CurrencySelector />
+      </CurrencyProvider>
+    );
+
+    // Verify initial currency is USD
+    expect(screen.getByText('USD')).toBeInTheDocument();
+    expect(screen.getByText('🇺🇸')).toBeInTheDocument();
+
+    // Click on currency selector to open dropdown
+    const currencyButton = screen.getByRole('button');
+    await user.click(currencyButton);
+
+    // Select INR from the dropdown
+    const inrOption = screen.getByText(/Indian Rupee \(INR\)/i);
+    await user.click(inrOption);
+
+    // Verify localStorage.setItem was called with correct values
+    expect(localStorageMock.setItem).toHaveBeenCalledWith('currencyCode', 'INR');
+
+    // Verify UI updated to show INR
+    expect(screen.getByText('INR')).toBeInTheDocument();
+    expect(screen.getByText('🇮🇳')).toBeInTheDocument();
+
+    // Unmount the component
+    unmount();
+
+    // Re-render the component to simulate page refresh
+    render(
+      <CurrencyProvider>
+        <CurrencySelector />
+      </CurrencyProvider>
+    );
+
+    // Verify the component initialized with INR from localStorage
+    expect(localStorageMock.getItem).toHaveBeenCalledWith('currencyCode');
+    expect(screen.getByText('INR')).toBeInTheDocument();
+    expect(screen.getByText('🇮🇳')).toBeInTheDocument();
+  });
+
+  it('should persist EUR selection to localStorage', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <CurrencyProvider>
+        <CurrencySelector />
+      </CurrencyProvider>
+    );
+
+    // Click on currency selector to open dropdown
+    const currencyButton = screen.getByRole('button');
+    await user.click(currencyButton);
+
+    // Select EUR from the dropdown
+    const eurOption = screen.getByText(/Euro \(EUR\)/i);
+    await user.click(eurOption);
+
+    // Verify localStorage.setItem was called with correct values
+    expect(localStorageMock.setItem).toHaveBeenCalledWith('currencyCode', 'EUR');
+
+    // Verify UI updated to show EUR
+    expect(screen.getByText('EUR')).toBeInTheDocument();
+    expect(screen.getByText('🇪🇺')).toBeInTheDocument();
+  });
+
+  it('should default to USD when localStorage is empty', () => {
+    render(
+      <CurrencyProvider>
+        <CurrencySelector />
+      </CurrencyProvider>
+    );
+
+    // Verify default currency is USD
+    expect(screen.getByText('USD')).toBeInTheDocument();
+    expect(screen.getByText('🇺🇸')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/CurrencySelector.test.jsx
+++ b/frontend/src/components/CurrencySelector.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import CurrencySelector from './CurrencySelector';

--- a/frontend/src/pages/TransactionPage.test.jsx
+++ b/frontend/src/pages/TransactionPage.test.jsx
@@ -7,7 +7,6 @@ describe("handleExportCSV", () => {
   let mockGet;
   let mockCreateObjectURL;
   let mockRevokeObjectURL;
-  let mockCreateElement;
   let mockAppendChild;
   let mockClick;
   let mockRemove;
@@ -32,7 +31,7 @@ describe("handleExportCSV", () => {
     mockRemove = vi.fn();
     mockAppendChild = vi.spyOn(document.body, "appendChild").mockImplementation(() => {});
 
-    mockCreateElement = vi.spyOn(document, "createElement").mockImplementation(() => ({
+    vi.spyOn(document, "createElement").mockImplementation(() => ({
       href: "",
       download: "",
       click: mockClick,

--- a/frontend/src/pages/TransactionsPage.jsx
+++ b/frontend/src/pages/TransactionsPage.jsx
@@ -192,4 +192,5 @@ const TransactionsPage = () => {
   );
 };
 
+// eslint-disable-next-line react-refresh/only-export-components
 export {TransactionsPage,handleExportCSV};


### PR DESCRIPTION
## Description
  Added comprehensive frontend tests for the `CurrencySelector` component to verify that user currency preferences are correctly
  persisted to localStorage and restored on page refresh. The test suite includes:
  - Currency selection persistence across component re-renders
  - Verification of localStorage interactions (setItem/getItem)
  - Default behavior when localStorage is empty
  - Multiple currency selection scenarios (INR, EUR)

  ## Related Issue
  Fixes #35 [test: Currency selection persists after page refresh](https://github.com/Code-A2Z/paisable/issues/35)  

  ## Motivation and Context
  The application allows users to select a preferred currency, which should persist across browser sessions. While this
  functionality works correctly in the browser, there was no automated test coverage to ensure the localStorage persistence logic
  remains functional. This test prevents future regressions that could break the currency preference feature.

  ## Types of Changes
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Enhancement (improvement to an existing feature)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [x] Test (adds or updates tests only)
  - [ ] Documentation (non-code change)

  ## How Has This Been Tested?
  **Test Environment:**
  - Vitest with jsdom environment
  - @testing-library/react for component testing
  - @testing-library/user-event for user interactions
  - Mocked localStorage with spy functions

  **Test Coverage:**
  1. **Persistence test**: Simulates user selecting INR, verifies localStorage.setItem is called, unmounts component, re-renders,
  and confirms INR is loaded from localStorage
  2. **EUR selection test**: Verifies EUR can be selected and persisted correctly
  3. **Default behavior test**: Confirms USD is shown when localStorage is empty

  **Test Results:**
  ✓ src/components/CurrencySelector.test.jsx (3 tests)
    ✓ should persist currency selection to localStorage and reload it on re-render
    ✓ should persist EUR selection to localStorage
    ✓ should default to USD when localStorage is empty

  Test Files  1 passed (1)
  Tests       3 passed (3)

  **Additional Verification:**
  - ✅ All existing tests still pass (6/6)
  - ✅ Linting passes with no errors
  - ✅ Build succeeds

  ## Screenshots (if applicable):
  N/A - This PR only adds tests

  ## Checklist
  - [x] My code follows the code style of this project
  - [ ] My change requires a change to the documentation
  - [ ] I have updated the documentation accordingly
  - [x] I have added tests to cover my changes
  - [x] All new and existing tests passed