### PR TITLE
fix: dashboard "Expenses by Category" layout overflow.

### DIFF
--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -105,7 +105,7 @@ const DashboardPage = () => {
           {loading ? <Spinner /> : chartData?.expensesByCategory.length > 0 ? (
     <CategoryPieChart data={chartData.expensesByCategory} theme={theme} />
   ) : (
-    <div className="h-full flex items-center justify-center bg-gray-100 dark:bg-gray-700 rounded"><p className="text-gray-500 dark:text-gray-400">No expense data to display.</p></div>
+    <div className="h-80 flex items-center justify-center bg-gray-100 dark:bg-gray-700 rounded"><p className="text-gray-500 dark:text-gray-400">No expense data to display.</p></div>
   )}
         </div>
         <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed the issue where the "Expenses by Category" section overflows its container on the dashboard. Now, the box stays contained within its card boundaries and scales properly even when no expense data is available.

## Related Issue
<!--- If this PR addresses an existing issue, link it here -->
Fixes #49 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The previous layout broke the design of the dashboard, especially noticeable when there were no expenses. This fix ensures a cleaner, responsive display for all users.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improvement to an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Test (adds or updates tests only)
- [ ] Documentation (non-code change)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Checked dashboard layout with multiple and no expense data.
- Verified that the "Expenses by Category" box remains within container boundaries across different screen sizes.

## Screenshots (if applicable):
<!--- Add screenshots or screen recordings if UI is affected -->
<img width="643" height="571" alt="Screenshot 2025-10-02 at 8 00 42 PM" src="https://github.com/user-attachments/assets/c256b663-b8e7-47ea-8d74-b4afaa22ca69" />

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

