### PR TITLE
Display error on frontend when login fails

### DIFF
--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -51,6 +51,7 @@ export const AuthProvider = ({ children }) => {
       }
     } catch (error) {
       console.error('Login failed', error.response?.data);
+      throw new Error(error.response?.data?.message || 'Login failed. Please try again.');
     }
   };
 

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -10,11 +10,17 @@ const DEMO_PASSWORD = 'password123'; */
 export default function LoginPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [serverError, setServerError] = useState('');
   const { login } = useAuth();
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    login(email, password);
+    setServerError(''); // Clear previous server errors
+    try {
+      await login(email, password);
+    } catch (error) {
+      setServerError(error.message);
+    }
   };
 
   /* const handleFillDemoCredentials = () => {
@@ -30,6 +36,7 @@ export default function LoginPage() {
 
       <div className="px-8 py-6 text-left bg-white dark:bg-gray-800 shadow-lg rounded-lg w-full max-w-md">
         <h3 className="text-2xl font-bold text-center text-gray-800 dark:text-gray-200">Login to your account</h3>
+        {serverError && <p className="text-center text-red-500 bg-red-100 dark:bg-red-900/50 p-2 rounded-md my-4">{serverError}</p>}
         <form onSubmit={handleSubmit}>
           <div className="mt-4">
             <div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Shown the server error message while loggin in to the user on the frontend,
## Description
<!--- Describe your changes in detail -->
Made the login function in the context file to throw the error. Caught the error in the login page, added await for the async login function, shown the error while loggin in on the frontend.

## Related Issue
<!--- If this PR addresses an existing issue, link it here -->
Fixes #82 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Earlier, when a user types an incorrect password, for example, the frontend does not show any visual warning. This makes the user clicking again and again on the login button but nothing happens. If we show the error message on the login form, it will inform the user on the very first try.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x] Enhancement (improvement to an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Test (adds or updates tests only)
- [ ] Documentation (non-code change)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested on local setup by running api and frontend on localhost. Build also passes successfully.

## Screenshots (if applicable):
<!--- Add screenshots or screen recordings if UI is affected -->
<img width="1857" height="1085" alt="image" src="https://github.com/user-attachments/assets/439c9b41-fc2e-4cc9-8867-a37abac66233" />


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

